### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -11,13 +11,13 @@ jobs:
         python-version: ['3.8', '3.9', '3.10']
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4.1.3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5.1.0
       with:
         python-version: ${{ matrix.python-version }}
     - name: Cache pip
-      uses: actions/cache@v3
+      uses: actions/cache@v4.0.2
       with:
         # This path is specific to Ubuntu
         path: ~/.cache/pip
@@ -45,7 +45,7 @@ jobs:
         make test
         coverage xml
     - name: Run codacy-coverage-reporter
-      uses: codacy/codacy-coverage-reporter-action@v1
+      uses: codacy/codacy-coverage-reporter-action@v1.3.0
       with:
         project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
         coverage-reports: coverage.xml

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4.1.3
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5.1.0
       with:
         python-version: '3.x'
     - name: Install dependencies

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -4,5 +4,5 @@ jobs:
     ruff:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v4.1.3
             - uses: chartboost/ruff-action@v1

--- a/.github/workflows/updater.yaml
+++ b/.github/workflows/updater.yaml
@@ -13,7 +13,7 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v4.1.3
               with:
                   # [Required] Access token with `workflow` scope.
                   token: ${{ secrets.UPDATER_TOKEN }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.1.3](https://github.com/actions/checkout/releases/tag/v4.1.3)** on 2024-04-19T14:56:44Z
* **[actions/cache](https://github.com/actions/cache)** published a new release **[v4.0.2](https://github.com/actions/cache/releases/tag/v4.0.2)** on 2024-03-19T15:55:41Z
* **[actions/setup-python](https://github.com/actions/setup-python)** published a new release **[v5.1.0](https://github.com/actions/setup-python/releases/tag/v5.1.0)** on 2024-03-26T14:09:17Z
* **[codacy/codacy-coverage-reporter-action](https://github.com/codacy/codacy-coverage-reporter-action)** published a new release **[v1.3.0](https://github.com/codacy/codacy-coverage-reporter-action/releases/tag/v1.3.0)** on 2022-01-19T14:07:50Z
