### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -10,13 +10,13 @@ jobs:
                 python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
         steps:
-            - uses: actions/checkout@v4.1.7
+            - uses: actions/checkout@v4.2.1
             - name: Set up Python ${{ matrix.python-version }}
               uses: actions/setup-python@v5.2.0
               with:
                   python-version: ${{ matrix.python-version }}
             - name: Cache pip
-              uses: actions/cache@v4.0.2
+              uses: actions/cache@v4.1.1
               with:
                   # This path is specific to Ubuntu
                   path:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4.1.7
+    - uses: actions/checkout@v4.2.1
     - name: Set up Python
       uses: actions/setup-python@v5.2.0
       with:

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -4,5 +4,5 @@ jobs:
     ruff:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4.1.7
+            - uses: actions/checkout@v4.2.1
             - uses: chartboost/ruff-action@v1

--- a/.github/workflows/updater.yaml
+++ b/.github/workflows/updater.yaml
@@ -13,7 +13,7 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - uses: actions/checkout@v4.1.7
+            - uses: actions/checkout@v4.2.1
               with:
                   # [Required] Access token with `workflow` scope.
                   token: ${{ secrets.UPDATER_TOKEN }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/cache](https://github.com/actions/cache)** published a new release **[v4.1.1](https://github.com/actions/cache/releases/tag/v4.1.1)** on 2024-10-08T17:09:10Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.2.1](https://github.com/actions/checkout/releases/tag/v4.2.1)** on 2024-10-07T16:44:53Z
