### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -16,7 +16,7 @@ jobs:
               with:
                   python-version: ${{ matrix.python-version }}
             - name: Cache pip
-              uses: actions/cache@v4.2.2
+              uses: actions/cache@v4.2.3
               with:
                   # This path is specific to Ubuntu
                   path:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -29,4 +29,4 @@ jobs:
     - name: Build
       run: hatch build
     - name: Publish to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
+      uses: pypa/gh-action-pypi-publish@v1.12.4


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/cache](https://github.com/actions/cache)** published a new release **[v4.2.3](https://github.com/actions/cache/releases/tag/v4.2.3)** on 2025-03-19T18:18:32Z
* **[pypa/gh-action-pypi-publish](https://github.com/pypa/gh-action-pypi-publish)** published a new release **[v1.12.4](https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.12.4)** on 2025-01-24T03:29:15Z
